### PR TITLE
Add CI for external tools

### DIFF
--- a/.github/workflows/python-test-conda-external.yml
+++ b/.github/workflows/python-test-conda-external.yml
@@ -1,0 +1,75 @@
+name: Unit tests external tools
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  run-nosetests:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: fred
+    - uses: actions/checkout@v2
+      with:
+        repository: kohlbacherlab/fred-tools
+        token: ${{ secrets.FRED_CI_PAT }}
+        path: fred-tools
+    - name: Install fred-tools system dependencies
+      run:
+        apt-fast install -y tcsh
+    - name: fred-tools post scripts
+      working-directory: ./fred-tools/
+      run: |
+        ./post.runner
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+    - name: Set conda package directory
+      run: |
+        mkdir /tmp/condapkgs
+        echo "CONDA_PKGS_DIRS=/tmp/condapkgs" >> $GITHUB_ENV
+    - name: Activate fred-tools
+      run: |
+        echo "$PWD/fred-tools/bin" >> $GITHUB_PATH
+        echo "PATH=$PATH"
+    - name: Install test dependencies and dependencies that pip would build from source
+      run: |
+        $CONDA/bin/conda create -p /tmp/condaenv -c conda-forge -c bioconda 'python<3' biopython svmlight==6.02 'tensorflow<2.0.0,>=1.1.0' 'markdown<=3.1' coincbc
+        export PATH="/tmp/condaenv/bin:$PATH"
+    - name: Activate conda environment
+      run: |
+        echo "/tmp/condaenv/bin" >> $GITHUB_PATH
+    - name: Install FRED
+      run: |
+        pip install keras==2.3.1 ./fred/
+    - name: Set up test environment
+      run: |
+        conda install -p /tmp/condaenv -c conda-forge -c bioconda nose
+    - name: Run Tests - Cleavage Prediction
+      working-directory: ./fred/
+      continue-on-error: true
+      run: |
+        conda install -p /tmp/condaenv -c conda-forge -c bioconda nose
+        nosetests -v Fred2/test/external/TestExternalCleavagePrediction.py || echo "Cleavage Prediction" >> FAILED_TESTS
+    - name: Run Tests - Epitope Prediction
+      working-directory: ./fred/
+      run: |
+        conda install -p /tmp/condaenv -c conda-forge -c bioconda nose
+        nosetests -v Fred2/test/external/TestExternalEpitopePrediction.py || echo "Epitope Prediction" >> FAILED_TESTS
+    - name: Validate Test Results
+      working-directory: ./fred/
+      run: |
+        if [ -e FAILED_TESTS ]; then
+          echo "FAILED TESTS:" >&2
+          cat FAILED_TESTS
+          exit 1
+        fi

--- a/.github/workflows/python-test-conda.yml
+++ b/.github/workflows/python-test-conda.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Unit tests without external tools
 
 on:
   push:


### PR DESCRIPTION
This PR adds CI for the *external* (3rd party software) tests. The required tools are stored in a second, private repository and checked out as part of the CI process. Since this requires secrets from this repository (personal access token for repository access) these tests won't run for PRs from forks but only intra-repo PRs.

Currently supports: Epitope prediction (netMHC) and cleavage prediction (netchop).